### PR TITLE
Fix: Whitespace perseverance on note editor

### DIFF
--- a/src/pages/Note.jsx
+++ b/src/pages/Note.jsx
@@ -99,6 +99,7 @@ function Note() {
           value={note.text}
           onChange={(e) => dispatch({ type: "TEXT", payload: { text: e } })}
           readOnly={type === "TRASH"}
+          preserveWhitespace={true}
           placeholder="Start writing..."
         />
         <FormInput


### PR DESCRIPTION
Small fix to preserve white space in quill editor.